### PR TITLE
feat: styleguide

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "start": "vinxi start"
   },
   "dependencies": {
+    "@fontsource/poppins": "^5.2.6",
     "@tanstack/react-query": "^5.76.1",
     "@tanstack/react-query-devtools": "^5.76.1",
     "@tanstack/react-router": "^1.120.5",
     "@tanstack/react-router-devtools": "^1.120.6",
     "@tanstack/react-start": "^1.120.5",
+    "lucide-react": "^0.511.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/poppins':
+        specifier: ^5.2.6
+        version: 5.2.6
       '@tanstack/react-query':
         specifier: ^5.76.1
         version: 5.76.1(react@19.1.0)
@@ -23,6 +26,9 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.120.5
         version: 1.120.5(@tanstack/react-router@1.120.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/node@22.15.19)(db0@0.3.2)(ioredis@5.6.1)(jiti@2.4.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(terser@5.39.2)(tsx@4.19.4)(vite@6.3.5(@types/node@22.15.19)(jiti@2.4.2)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.0))(yaml@2.8.0)
+      lucide-react:
+        specifier: ^0.511.0
+        version: 0.511.0(react@19.1.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -627,6 +633,9 @@ packages:
 
   '@fastify/busboy@3.1.1':
     resolution: {integrity: sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==}
+
+  '@fontsource/poppins@5.2.6':
+    resolution: {integrity: sha512-NFr0121+vWCfzLDVvSZOzwAjRUaNj6QHA9gtUh/KHHoWf1Qn23EkwVFs63XZ6UtF5K1b3UNmCx77YEMGgV7BOQ==}
 
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
@@ -2465,6 +2474,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.511.0:
+    resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   luxon@3.6.1:
     resolution: {integrity: sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==}
     engines: {node: '>=12'}
@@ -4106,6 +4120,8 @@ snapshots:
     optional: true
 
   '@fastify/busboy@3.1.1': {}
+
+  '@fontsource/poppins@5.2.6': {}
 
   '@ioredis/commands@1.2.0': {}
 
@@ -6430,6 +6446,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.511.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   luxon@3.6.1: {}
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,19 +1,26 @@
+@import '@fontsource/poppins/500.css';
+@import '@fontsource/poppins/700.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   html {
-    color-scheme: light dark;
+    font-family: 'Poppins', sans-serif;
   }
 
   * {
-    @apply border-gray-200 dark:border-gray-800;
+    @apply border-gray;
   }
 
   html,
   body {
-    @apply text-gray-900 bg-gray-50 dark:bg-gray-950 dark:text-gray-200;
+    @apply text-very-dark-violet bg-white text-base font-medium;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-bold;
   }
 
   .using-mouse * {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,4 +1,37 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    screens: {
+      'sm': '375px',
+      'md': '1440px',
+    },
+    extend: {
+      colors: {
+        // Primary
+        'cyan': 'hsl(180, 66%, 49%)',
+        'dark-violet': 'hsl(257, 27%, 26%)',
+        
+        // Secondary
+        'red': 'hsl(0, 87%, 67%)',
+        
+        // Neutral
+        'gray': 'hsl(0, 0%, 75%)',
+        'grayish-violet': 'hsl(257, 7%, 63%)',
+        'very-dark-blue': 'hsl(255, 11%, 22%)',
+        'very-dark-violet': 'hsl(260, 8%, 14%)',
+      },
+      fontFamily: {
+        'sans': ['Poppins', 'ui-sans-serif', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
+      },
+      fontSize: {
+        'base': '18px',
+      },
+      fontWeight: {
+        'medium': '500',
+        'bold': '700',
+      },
+    },
+  },
+  plugins: [],
 }


### PR DESCRIPTION
Closes #1 

Update's tailwind config to match styleguide. 
Adds font from @fontsource/poppins npm package.
Adds lucide-icons for iconography.